### PR TITLE
[HEA-1407] Depend on node v22

### DIFF
--- a/friday-beta.rb
+++ b/friday-beta.rb
@@ -23,7 +23,7 @@ class FridayBeta < Formula
   depends_on "gh"
   depends_on "fd"
   depends_on "ripgrep"
-  depends_on "node"
+  depends_on "node@22"
 
   def install
     if !Hardware::CPU.arm?

--- a/friday.rb
+++ b/friday.rb
@@ -21,7 +21,7 @@ class Friday < Formula
   depends_on "gh"
   depends_on "fd"
   depends_on "ripgrep"
-  depends_on "node"
+  depends_on "node@22"
 
   def install
     if !Hardware::CPU.arm?


### PR DESCRIPTION
Using the @ function in `depends_on` allows us to pull in a specified version - in this instance we want [Node V22](https://formulae.brew.sh/formula/node@22), so we simply do
```
depends_on "node@22"
```
Homebrew formula docs are [here](https://docs.brew.sh/Versions) they're detailed and comprehensive.
Also, this was my first time writing Ruby 🙂 
