### PR TITLE
Fix pyexpat dlopen error: add expat dep and DYLD_LIBRARY_PATH in wrapper

### DIFF
--- a/friday-beta.rb
+++ b/friday-beta.rb
@@ -24,6 +24,7 @@ class FridayBeta < Formula
   depends_on "fd"
   depends_on "ripgrep"
   depends_on "node@22"
+  depends_on "expat"
   depends_on "python@3.12"
 
   def install
@@ -36,6 +37,8 @@ class FridayBeta < Formula
     chmod 0755, bin/"friday-bin"
 
     # Create wrapper script for friday
+    # Sets DYLD_LIBRARY_PATH to use Homebrew expat, fixing pyexpat dlopen error
+    # where system libexpat stub is missing _XML_SetAllocTrackerActivationThreshold
     (bin/"friday").write <<~EOS
       #!/bin/bash
       case "$1" in
@@ -48,6 +51,7 @@ class FridayBeta < Formula
           exit $?
           ;;
       esac
+      export DYLD_LIBRARY_PATH="#{Formula["expat"].opt_lib}:${DYLD_LIBRARY_PATH}"
       exec "#{bin}/friday-bin" "$@"
     EOS
     chmod 0755, bin/"friday"

--- a/friday.rb
+++ b/friday.rb
@@ -22,6 +22,7 @@ class Friday < Formula
   depends_on "fd"
   depends_on "ripgrep"
   depends_on "node@22"
+  depends_on "expat"
   depends_on "python@3.12"
 
   def install
@@ -34,6 +35,8 @@ class Friday < Formula
     chmod 0755, bin/"friday-bin"
 
     # Create wrapper script for friday
+    # Sets DYLD_LIBRARY_PATH to use Homebrew expat, fixing pyexpat dlopen error
+    # where system libexpat stub is missing _XML_SetAllocTrackerActivationThreshold
     (bin/"friday").write <<~EOS
       #!/bin/bash
       case "$1" in
@@ -46,6 +49,7 @@ class Friday < Formula
           exit $?
           ;;
       esac
+      export DYLD_LIBRARY_PATH="#{Formula["expat"].opt_lib}:${DYLD_LIBRARY_PATH}"
       exec "#{bin}/friday-bin" "$@"
     EOS
     chmod 0755, bin/"friday"


### PR DESCRIPTION
## Problem

On macOS, `friday` crashes on startup with:

```
ImportError: dlopen(pyexpat.cpython-312-darwin.so): Symbol not found: _XML_SetAllocTrackerActivationThreshold
Expected in: /usr/lib/libexpat.1.dylib
```

The system `libexpat` stub is missing `_XML_SetAllocTrackerActivationThreshold`, which `python@3.12`'s `pyexpat.so` requires. This causes a startup crash through:

`InquirerPy → prompt_toolkit → HTML() → minidom → pyexpat → dlopen fail`

## Fix

Add Homebrew `expat` as a dependency in `friday.rb` and `friday-beta.rb`, and prepend its lib path to `DYLD_LIBRARY_PATH` in the wrapper script so `libexpat` resolves to the Homebrew version instead of the incomplete system stub.

## Alternative workaround (reported by users)

```bash
brew reinstall --build-from-source python@3.12
rm -rf /opt/homebrew/etc/friday/cache/
```

This works by rebuilding `pyexpat.so` against the locally available `libexpat`, but requires a full Python rebuild. This PR is the lighter runtime fix.